### PR TITLE
cfg80211: Correct API cfg80211_vendor_cmd_reply_skb

### DIFF
--- a/include/net/cfg80211.h
+++ b/include/net/cfg80211.h
@@ -3302,8 +3302,8 @@ void __cfg80211_send_event_skb(struct sk_buff *skb, gfp_t gfp);
 static inline struct sk_buff *
 cfg80211_vendor_cmd_alloc_reply_skb(struct wiphy *wiphy, int approxlen)
 {
-	return __cfg80211_alloc_reply_skb(wiphy, NL80211_CMD_TESTMODE,
-					  NL80211_ATTR_TESTDATA, approxlen);
+	return __cfg80211_alloc_reply_skb(wiphy, NL80211_CMD_VENDOR,
+					  NL80211_ATTR_VENDOR_DATA, approxlen);
 }
 
 /**


### PR DESCRIPTION
Correct the definition of API cfg80211_vendor_cmd_reply_skb. Use the
correct value of command and attribute. This fixes the merge error when
open source commit ad7e718c9b4f717823fd920a0103f7b0fb06183f was pulled
into the tree.

Change-Id: Ibe83feba088fa6933bbef7a6c79cd72e6eda64b0
Signed-off-by: Amar Singhal <asinghal@codeaurora.org>